### PR TITLE
Add Flask Excel upload app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+uploads/*
+!uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# smart-sheet-editor-python
+# Smart Sheet Editor Python
+
+This simple Flask application allows uploading Excel `.xlsx` files from the browser and returns their contents as JSON. The app reads every sheet in the workbook using `pandas` and `openpyxl`.
+
+## Setup
+
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000/` in the browser to test uploading a file.
+
+Uploaded files are stored temporarily in the `uploads/` directory and deleted immediately after being processed.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,40 @@
+from flask import Flask, request, jsonify, send_from_directory
+from flask_cors import CORS
+import pandas as pd
+import os
+import tempfile
+
+app = Flask(__name__, static_folder='public', static_url_path='')
+CORS(app)
+
+UPLOAD_FOLDER = 'uploads'
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+@app.route('/')
+def index():
+    return send_from_directory(app.static_folder, 'index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file part'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'error': 'No selected file'}), 400
+    if not file.filename.lower().endswith('.xlsx'):
+        return jsonify({'error': 'Invalid file type'}), 400
+
+    # Save to a temporary file within uploads folder
+    fd, path = tempfile.mkstemp(dir=UPLOAD_FOLDER, suffix='.xlsx')
+    try:
+        with os.fdopen(fd, 'wb') as tmp:
+            file.save(tmp)
+        # Read all sheets
+        xl = pd.read_excel(path, sheet_name=None, engine='openpyxl')
+        sheets = [{'name': name, 'data': data.fillna('').values.tolist()} for name, data in xl.items()]
+        return jsonify({'sheets': sheets})
+    finally:
+        os.remove(path)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Excel Upload</title>
+</head>
+<body>
+<input type="file" id="fileInput" accept=".xlsx"/>
+<button onclick="upload()">Upload</button>
+<pre id="output"></pre>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,13 @@
+async function upload() {
+  const input = document.getElementById('fileInput');
+  if (!input.files.length) return;
+  const file = input.files[0];
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch('/upload', {
+    method: 'POST',
+    body: formData
+  });
+  const json = await res.json();
+  document.getElementById('output').textContent = JSON.stringify(json, null, 2);
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-Cors
+pandas
+openpyxl


### PR DESCRIPTION
## Summary
- add minimal Flask app with Excel upload capability
- serve static index and script from `public/`
- keep temporary uploads and remove them after processing
- add Flask, pandas, openpyxl, and Flask-CORS requirements
- document setup in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68795d7204a083238857bcadc75ce672